### PR TITLE
epub: close non-self closing tags

### DIFF
--- a/src/epub/epub_templates.js
+++ b/src/epub/epub_templates.js
@@ -95,6 +95,9 @@ ${dateLine}
       ? `<p class="meta">${metaParts.join(' • ')}</p>`
       : '';
 
+    // Convert HTML body to XHTML (properly close self-closing tags)
+    const xhtmlBody = this.htmlToXhtml(body);
+
     return `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
@@ -138,7 +141,7 @@ ${dateLine}
   <h1>${this.escapeXml(title)}</h1>
   ${metaLine}
   <div class="content">
-    ${body}
+    ${xhtmlBody}
   </div>
 </body>
 </html>`;
@@ -146,7 +149,7 @@ ${dateLine}
 
   /**
    * Escape XML special characters
-   * @param {string} text 
+   * @param {string} text
    */
   escapeXml(text) {
     if (!text) return '';
@@ -158,5 +161,29 @@ ${dateLine}
       "'": '&apos;'
     };
     return String(text).replace(/[&<>"']/g, m => map[m]);
+  },
+
+  /**
+   * Convert HTML to XHTML by properly closing self-closing tags
+   * @param {string} html
+   */
+  htmlToXhtml(html) {
+    if (!html) return '';
+
+    // List of void/self-closing elements in HTML that must be self-closed in XHTML
+    const voidElements = [
+      'area', 'base', 'br', 'col', 'embed', 'hr', 'img', 'input',
+      'link', 'meta', 'param', 'source', 'track', 'wbr'
+    ];
+
+    // Pattern to match void elements that are not already self-closed
+    // Matches: <tag ...> but not <tag ... /> or <tag .../>
+    const pattern = new RegExp(
+      `<(${voidElements.join('|')})([^>]*?)(?<!/)>`,
+      'gi'
+    );
+
+    // Replace with self-closing version
+    return html.replace(pattern, '<$1$2 />');
   }
 };


### PR DESCRIPTION
<img> is valid in HTML5 but not in XHTML used in EPUB. Use a regexp (yes, it's a bad idea) to close non-closed tags.

Closes #3