### PR TITLE
Adds header support for substack articles

### DIFF
--- a/src/content/extraction_helpers.js
+++ b/src/content/extraction_helpers.js
@@ -1,0 +1,59 @@
+(function (root, factory) {
+  const api = factory();
+
+  if (typeof module === 'object' && module.exports) {
+    module.exports = api;
+  }
+
+  root.X4ExtractionHelpers = api;
+})(typeof globalThis !== 'undefined' ? globalThis : this, function () {
+  const HEADING_CLASS_TOKEN_RE = /(^|[-_])(header|anchor)([-_]|$)/i;
+
+  function countHeadingTags(html, minLevel = 2, maxLevel = 3) {
+    if (!html || minLevel > maxLevel) return 0;
+
+    let total = 0;
+    for (let level = minLevel; level <= maxLevel; level++) {
+      const re = new RegExp(`<h${level}\\b`, 'gi');
+      total += (html.match(re) || []).length;
+    }
+    return total;
+  }
+
+  function sanitizeHeadingClasses(rootNode) {
+    if (!rootNode || typeof rootNode.querySelectorAll !== 'function') {
+      return 0;
+    }
+
+    let removedCount = 0;
+    const headings = rootNode.querySelectorAll('h1,h2,h3,h4,h5,h6');
+
+    headings.forEach((heading) => {
+      if (!heading || typeof heading.className !== 'string' || !heading.className) {
+        return;
+      }
+
+      const classes = heading.className.split(/\s+/).filter(Boolean);
+      if (classes.length === 0) return;
+
+      const kept = classes.filter((token) => !HEADING_CLASS_TOKEN_RE.test(token));
+      removedCount += classes.length - kept.length;
+
+      if (kept.length !== classes.length) {
+        heading.className = kept.join(' ');
+      }
+    });
+
+    return removedCount;
+  }
+
+  function shouldUseHeadingFallback(sourceHtml, parsedHtml) {
+    return countHeadingTags(sourceHtml) > 0 && countHeadingTags(parsedHtml) === 0;
+  }
+
+  return {
+    countHeadingTags,
+    sanitizeHeadingClasses,
+    shouldUseHeadingFallback
+  };
+});

--- a/src/popup/modules/article_manager.js
+++ b/src/popup/modules/article_manager.js
@@ -37,7 +37,7 @@ export class ArticleManager {
                 // However, executeScript files: [] runs immediately.
                 await browserAPI.scripting.executeScript({
                     target: { tabId: tab.id },
-                    files: ['src/content/readability.min.js']
+                    files: ['src/content/extraction_helpers.js', 'src/content/readability.min.js']
                 });
                 console.log('[Article Manager] Readability injected');
             } catch (injectError) {

--- a/src/popup/modules/extraction_logic.js
+++ b/src/popup/modules/extraction_logic.js
@@ -43,6 +43,8 @@ export function extractArticle() {
         };
 
         const getStructuredContentRoot = () => {
+            // Prefer structured content roots (including Substack-like markup)
+            // when Readability strips section headings from parsed output.
             const selectors = [
                 '.available-content .body.markup',
                 '.single-post-container .available-content',

--- a/src/popup/modules/extraction_logic.js
+++ b/src/popup/modules/extraction_logic.js
@@ -7,6 +7,59 @@ export function extractArticle() {
     try {
         console.log('[X4] Extracting article...');
         const hostname = window.location.hostname;
+        const extractionHelpers = window.X4ExtractionHelpers || {
+            countHeadingTags(html, minLevel = 2, maxLevel = 3) {
+                if (!html || minLevel > maxLevel) return 0;
+                let total = 0;
+                for (let level = minLevel; level <= maxLevel; level++) {
+                    const re = new RegExp(`<h${level}\\b`, 'gi');
+                    total += (html.match(re) || []).length;
+                }
+                return total;
+            },
+            sanitizeHeadingClasses(rootNode) {
+                if (!rootNode || typeof rootNode.querySelectorAll !== 'function') {
+                    return 0;
+                }
+                const classTokenRe = /(^|[-_])(header|anchor)([-_]|$)/i;
+                let removedCount = 0;
+                rootNode.querySelectorAll('h1,h2,h3,h4,h5,h6').forEach((heading) => {
+                    if (!heading || typeof heading.className !== 'string' || !heading.className) {
+                        return;
+                    }
+                    const classes = heading.className.split(/\s+/).filter(Boolean);
+                    if (classes.length === 0) return;
+                    const kept = classes.filter((token) => !classTokenRe.test(token));
+                    removedCount += classes.length - kept.length;
+                    if (kept.length !== classes.length) {
+                        heading.className = kept.join(' ');
+                    }
+                });
+                return removedCount;
+            },
+            shouldUseHeadingFallback(sourceHtml, parsedHtml) {
+                return this.countHeadingTags(sourceHtml) > 0 && this.countHeadingTags(parsedHtml) === 0;
+            }
+        };
+
+        const getStructuredContentRoot = () => {
+            const selectors = [
+                '.available-content .body.markup',
+                '.single-post-container .available-content',
+                'article .body.markup',
+                'article .markup',
+                'article'
+            ];
+
+            for (const selector of selectors) {
+                const el = document.querySelector(selector);
+                if (el && (el.innerHTML || '').trim().length > 0) {
+                    return el;
+                }
+            }
+
+            return null;
+        };
 
         // --- TWITTER / X SUPPORT ---
         if (hostname.includes('twitter.com') || hostname.includes('x.com')) {
@@ -158,6 +211,7 @@ export function extractArticle() {
         if (hasReadability) {
             // Use Readability
             const docClone = document.cloneNode(true);
+            extractionHelpers.sanitizeHeadingClasses(docClone);
             const reader = new Readability(docClone);
             const article = reader.parse();
 
@@ -167,6 +221,17 @@ export function extractArticle() {
                 body = article.content;
                 textContent = article.textContent;
                 wordCount = textContent.split(/\s+/).length;
+
+                const structuredRoot = getStructuredContentRoot();
+                if (structuredRoot) {
+                    const sourceHtml = structuredRoot.innerHTML || '';
+                    if (extractionHelpers.shouldUseHeadingFallback(sourceHtml, body)) {
+                        console.log('[X4] Readability dropped headings; using structured source body fallback');
+                        body = sourceHtml;
+                        textContent = structuredRoot.innerText || structuredRoot.textContent || textContent;
+                        wordCount = textContent.split(/\s+/).filter(Boolean).length;
+                    }
+                }
 
                 // Try to get date
                 const dateEl = document.querySelector('meta[property="article:published_time"]') ||

--- a/tests/extraction_helpers.test.js
+++ b/tests/extraction_helpers.test.js
@@ -1,0 +1,46 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  countHeadingTags,
+  sanitizeHeadingClasses,
+  shouldUseHeadingFallback
+} = require('../src/content/extraction_helpers.js');
+
+test('countHeadingTags counts h2/h3 by default', () => {
+  const html = '<h2>One</h2><p>x</p><h3>Two</h3><h4>Three</h4>';
+  assert.equal(countHeadingTags(html), 2);
+});
+
+test('sanitizeHeadingClasses removes header/anchor-like class tokens on headings', () => {
+  const headingA = { className: 'header-anchor-post keep-me' };
+  const headingB = { className: 'section-title anchor-link' };
+  const headingC = { className: '' };
+  const root = {
+    querySelectorAll() {
+      return [headingA, headingB, headingC];
+    }
+  };
+
+  const removed = sanitizeHeadingClasses(root);
+
+  assert.equal(removed, 2);
+  assert.equal(headingA.className, 'keep-me');
+  assert.equal(headingB.className, 'section-title');
+  assert.equal(headingC.className, '');
+});
+
+test('shouldUseHeadingFallback is true only when source has headings and parsed has none', () => {
+  assert.equal(
+    shouldUseHeadingFallback('<p>x</p><h2>Section</h2>', '<p>x</p>'),
+    true
+  );
+  assert.equal(
+    shouldUseHeadingFallback('<p>x</p><h2>Section</h2>', '<p>x</p><h2>Section</h2>'),
+    false
+  );
+  assert.equal(
+    shouldUseHeadingFallback('<p>x</p>', '<p>x</p>'),
+    false
+  );
+});


### PR DESCRIPTION
This PR ensures that headers in the HTML are preserved in the extracted content.

Previously, headers (h2 elements) were being stripped when parsing a substack article. I've attached an HTML example that can be used as a test input for validation.

Tested the unpacked extension in chrome after these changes, and the article works as expected now. This is an unfortunate workaround of a Readability issue that hasn't seen much traction: https://github.com/mozilla/readability/issues/928

Before:
<img width="483" height="667" alt="image" src="https://github.com/user-attachments/assets/b227bc2d-8e34-41b8-ae99-21d18fc6703d" />

After:
<img width="454" height="698" alt="image" src="https://github.com/user-attachments/assets/97b30917-ff43-4368-b5c0-865b76e269c3" />


Input file: [How Codex is built - by Gergely Orosz.html](https://github.com/user-attachments/files/25454213/How.Codex.is.built.-.by.Gergely.Orosz.html)
