### PR TITLE
feat: add minimal external API bridge for trusted websites

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -17,6 +17,13 @@
     "http://192.168.1.224/*",
     "<all_urls>"
   ],
+  "externally_connectable": {
+    "matches": [
+      "https://send-to-reader.antoinevidal.fr/*",
+      "https://send-to-reader.vercel.app/*",
+      "http://localhost:5193/*"
+    ]
+  },
   "background": {
     "service_worker": "src/background/service_worker.js",
     "scripts": [

--- a/src/background/service_worker.js
+++ b/src/background/service_worker.js
@@ -65,6 +65,90 @@ browserAPI.runtime.onMessage.addListener((message, sender, sendResponse) => {
 });
 
 /**
+ * External API bridge for trusted websites (e.g. Antoine's Archive).
+ * Minimal surface:
+ * - x4.ping
+ * - x4.status ({ firmwareType, host })
+ * - x4.upload ({ firmwareType, host, filename, dataBase64 })
+ */
+browserAPI.runtime.onMessageExternal.addListener((message, _sender, sendResponse) => {
+    if (!message || message.type !== 'X4_EXTERNAL_API') return;
+
+    (async () => {
+        try {
+            let data;
+            switch (message.action) {
+                case 'x4.ping':
+                    data = { ok: true };
+                    break;
+                case 'x4.status':
+                    data = await handleExternalStatus(message.payload || {});
+                    break;
+                case 'x4.upload':
+                    data = await handleExternalUpload(message.payload || {});
+                    break;
+                default:
+                    throw new Error(`Unsupported action: ${String(message.action)}`);
+            }
+            sendResponse({ ok: true, data });
+        } catch (error) {
+            sendResponse({ ok: false, error: error instanceof Error ? error.message : 'External API error' });
+        }
+    })();
+
+    return true;
+});
+
+function decodeBase64ToArrayBuffer(base64) {
+    const binary = atob(base64);
+    const bytes = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i += 1) bytes[i] = binary.charCodeAt(i);
+    return bytes.buffer;
+}
+
+async function handleExternalStatus(payload) {
+    const firmwareType = payload?.firmwareType === 'stock' ? 'stock' : 'crosspoint';
+    const host = (payload?.host || (firmwareType === 'crosspoint' ? '192.168.4.1' : '192.168.3.3')).trim();
+    const base = host.includes('://') ? host.replace(/\/+$/, '') : `http://${host.replace(/\/+$/, '')}`;
+
+    if (firmwareType === 'crosspoint') {
+        const response = await fetch(`${base}/api/status`, { method: 'GET' });
+        if (!response.ok) return { connected: false, error: `Status ${response.status}` };
+        const data = await response.json().catch(() => ({}));
+        return {
+            connected: true,
+            version: data?.version,
+            ip: data?.ip,
+            mode: data?.mode,
+        };
+    }
+
+    const response = await fetch(`${base}/list?dir=/`, { method: 'GET' });
+    if (!response.ok) return { connected: false, error: `Status ${response.status}` };
+    return { connected: true };
+}
+
+async function handleExternalUpload(payload) {
+    const firmwareType = payload?.firmwareType === 'stock' ? 'stock' : 'crosspoint';
+    const host = (payload?.host || (firmwareType === 'crosspoint' ? '192.168.4.1' : '192.168.3.3')).trim();
+    const filename = (payload?.filename || 'book.epub').trim() || 'book.epub';
+    const dataBase64 = payload?.dataBase64;
+    if (!dataBase64 || typeof dataBase64 !== 'string') {
+        return { success: false, error: 'Missing dataBase64' };
+    }
+
+    const arrayBuffer = decodeBase64ToArrayBuffer(dataBase64);
+
+    if (firmwareType === 'crosspoint') {
+        CrossPointUpload.setIp(host.replace(/^https?:\/\//i, ''));
+        return await CrossPointUpload.uploadEpub(arrayBuffer, filename);
+    }
+
+    X4UploadTab.setIp(host.replace(/^https?:\/\//i, ''));
+    return await X4UploadTab.uploadEpub(arrayBuffer, filename);
+}
+
+/**
  * Handle fetch proxy (to bypass CORS/Mixed Content in popup)
  */
 async function handleFetch(payload) {


### PR DESCRIPTION
Hello! 👋

I’ve been building Antoine’s Archive, a web app for Xteink users to discover books and send them to their X4 in a streamlined way.

I posted a demo here:
[Reddit demo thread](https://www.reddit.com/r/xteinkereader/comments/1sbr6gc/built_my_own_kindle_store_for_my_xteink_antoines/)

The goal is simple: make it easier for users to go from “found a book” to “sent to my X4” with as little friction as possible.

Right now, users often need multiple tools/extensions for similar upload actions. I’d love to avoid that duplication and use Send to X4 as the shared bridge.
So this PR proposes a small external API bridge that lets trusted websites call a few core actions (ping/status/upload), while keeping your existing popup workflow unchanged.

In short:

one extension ecosystem
less duplicated code
better UX for users
no breaking changes to current users

## Summary
- add `externally_connectable` allowlist for trusted website origins
- add a minimal `runtime.onMessageExternal` API in the service worker
- expose only 3 actions for website integration: `x4.ping`, `x4.status`, `x4.upload`

## Why
This keeps the extension popup-first behavior unchanged while allowing a trusted hosted UI (e.g. Antoine's Archive) to integrate without requiring users to configure both app settings and extension popup flows separately.

## API contract (minimal)
- `x4.ping` -> `{ ok: true }`
- `x4.status` with `{ firmwareType, host }` -> connectivity payload
- `x4.upload` with `{ firmwareType, host, filename, dataBase64 }` -> upload result

## Safety
- only explicitly allowlisted origins can call the external API
- unsupported actions return explicit errors
- no change to existing internal popup/runtime message routes

## Test plan
- [ ] install extension locally, keep existing popup flow working
- [ ] from an allowlisted site, call `x4.ping` and confirm success
- [ ] call `x4.status` with stock + crosspoint host settings
- [ ] call `x4.upload` and verify EPUB arrives on device

Made with [Cursor](https://cursor.com)