### PR TITLE
Fix Firefox EPUB filename validation

### DIFF
--- a/src/epub/epub_builder.js
+++ b/src/epub/epub_builder.js
@@ -4,12 +4,14 @@
  */
 
 // EpubBuilder will use the JSZip global from jszip.min.js (loaded via manifest)
+// Keep all possible metadata before applying the filesystem byte limit below.
+const MAX_EPUB_SANITIZED_BASENAME_CHARS = 500;
 const MAX_EPUB_BASENAME_BYTES = 240;
 
 /**
  * Limit a string by UTF-8 byte length without splitting a Unicode code point.
- * This leaves room for the .epub extension within common 255-byte filesystem
- * filename limits.
+ * Grapheme clusters can still be truncated. This leaves room for the .epub
+ * extension within common 255-byte filesystem filename limits.
  */
 function truncateUtf8(text, maxBytes) {
     const encoder = new TextEncoder();
@@ -136,7 +138,10 @@ const EpubBuilder = {
         // Sanitize the complete basename as a final safeguard. Metadata such as
         // dates and source domains are external input too. Limit its encoded
         // size, not its character count, because filenames are byte-limited.
-        const safeBasename = Sanitizer.sanitizeFilename(parts.join(' - '), 500);
+        const safeBasename = Sanitizer.sanitizeFilename(
+            parts.join(' - '),
+            MAX_EPUB_SANITIZED_BASENAME_CHARS
+        );
         const basename = truncateUtf8(safeBasename, MAX_EPUB_BASENAME_BYTES);
         return `${basename}.epub`;
     },

--- a/src/epub/epub_builder.js
+++ b/src/epub/epub_builder.js
@@ -110,7 +110,10 @@ const EpubBuilder = {
         const date = article.date || new Date().toISOString().split('T')[0];
         parts.push(date);
 
-        return parts.join(' - ') + '.epub';
+        // Sanitize the complete basename as a final safeguard. Metadata such as
+        // dates and source domains are external input too.
+        const basename = Sanitizer.sanitizeFilename(parts.join(' - '), 180);
+        return `${basename}.epub`;
     },
 
     /**

--- a/src/epub/epub_builder.js
+++ b/src/epub/epub_builder.js
@@ -4,6 +4,29 @@
  */
 
 // EpubBuilder will use the JSZip global from jszip.min.js (loaded via manifest)
+const MAX_EPUB_BASENAME_BYTES = 240;
+
+/**
+ * Limit a string by UTF-8 byte length without splitting a Unicode code point.
+ * This leaves room for the .epub extension within common 255-byte filesystem
+ * filename limits.
+ */
+function truncateUtf8(text, maxBytes) {
+    const encoder = new TextEncoder();
+    let result = '';
+    let byteLength = 0;
+
+    for (const character of text) {
+        const characterBytes = encoder.encode(character).length;
+        if (byteLength + characterBytes > maxBytes) break;
+
+        result += character;
+        byteLength += characterBytes;
+    }
+
+    return result.trimEnd() || 'untitled';
+}
+
 const EpubBuilder = {
     /**
      * Generate EPUB blob from article data
@@ -111,8 +134,10 @@ const EpubBuilder = {
         parts.push(date);
 
         // Sanitize the complete basename as a final safeguard. Metadata such as
-        // dates and source domains are external input too.
-        const basename = Sanitizer.sanitizeFilename(parts.join(' - '), 180);
+        // dates and source domains are external input too. Limit its encoded
+        // size, not its character count, because filenames are byte-limited.
+        const safeBasename = Sanitizer.sanitizeFilename(parts.join(' - '), 500);
+        const basename = truncateUtf8(safeBasename, MAX_EPUB_BASENAME_BYTES);
         return `${basename}.epub`;
     },
 

--- a/src/popup/modules/extraction_logic.js
+++ b/src/popup/modules/extraction_logic.js
@@ -165,9 +165,14 @@ export function extractArticle() {
             if (isoDate) return isoDate[0];
 
             const parsedDate = new Date(dateText);
-            return Number.isNaN(parsedDate.getTime())
-                ? null
-                : parsedDate.toISOString().split('T')[0];
+            if (Number.isNaN(parsedDate.getTime())) return null;
+
+            // Use local calendar components so a date-only source does not
+            // shift to the previous or next day during UTC conversion.
+            const year = String(parsedDate.getFullYear()).padStart(4, '0');
+            const month = String(parsedDate.getMonth() + 1).padStart(2, '0');
+            const day = String(parsedDate.getDate()).padStart(2, '0');
+            return `${year}-${month}-${day}`;
         };
 
         if (hasReadability) {

--- a/src/popup/modules/extraction_logic.js
+++ b/src/popup/modules/extraction_logic.js
@@ -241,7 +241,8 @@ export function extractArticle() {
             document.querySelector('time[datetime]');
         if (dateEl) {
             const dt = dateEl.getAttribute('content') || dateEl.getAttribute('datetime');
-            if (dt) date = dt.split('T')[0];
+            const normalizedDate = normalizeDate(dt);
+            if (normalizedDate) date = normalizedDate;
         }
 
         // Create simple HTML body

--- a/src/popup/modules/extraction_logic.js
+++ b/src/popup/modules/extraction_logic.js
@@ -155,6 +155,21 @@ export function extractArticle() {
         let textContent = '';
         let wordCount = 0;
 
+        // Browser download APIs require a filesystem-safe filename. Normalize
+        // common article date formats before they are incorporated into it.
+        const normalizeDate = (value) => {
+            if (!value) return null;
+
+            const dateText = String(value).trim();
+            const isoDate = dateText.match(/^\d{4}-\d{2}-\d{2}/);
+            if (isoDate) return isoDate[0];
+
+            const parsedDate = new Date(dateText);
+            return Number.isNaN(parsedDate.getTime())
+                ? null
+                : parsedDate.toISOString().split('T')[0];
+        };
+
         if (hasReadability) {
             // Use Readability
             const docClone = document.cloneNode(true);
@@ -171,12 +186,10 @@ export function extractArticle() {
                 // Try to get date
                 const dateEl = document.querySelector('meta[property="article:published_time"]') ||
                     document.querySelector('time[datetime]');
-                if (article.publishedTime) {
-                    date = article.publishedTime.split('T')[0];
-                } else if (dateEl) {
-                    const dt = dateEl.getAttribute('content') || dateEl.getAttribute('datetime');
-                    if (dt) date = dt.split('T')[0];
-                }
+                const extractedDate = article.publishedTime ||
+                    (dateEl && (dateEl.getAttribute('content') || dateEl.getAttribute('datetime')));
+                const normalizedDate = normalizeDate(extractedDate);
+                if (normalizedDate) date = normalizedDate;
 
                 // Get author from meta if not in article
                 if (!author) {


### PR DESCRIPTION
## Summary

Fix Firefox download failures caused by article metadata creating invalid EPUB filenames.

- Normalize article dates to `YYYY-MM-DD` in both Readability and fallback extraction paths.
- Sanitize the complete EPUB basename, including external source and date metadata.
- Limit filenames by UTF-8 byte length while preserving Unicode code points, leaving room for `.epub`.

## Root cause

Some sites expose dates such as `2026-02-04 12:00:00Z`. The previous extractor only split on `T`, allowing colons into the download filename, which Firefox rejects.

## Compatibility

The change uses standard JavaScript and `TextEncoder`, and remains compatible with Chrome MV3 and Firefox. The 240-byte basename limit prevents Unicode-heavy filenames from exceeding common filesystem limits.

## Validation

- Parsed ISO, space-delimited, and human-readable date formats to `2026-02-04` in both extraction paths.
- Verified invalid filename characters are removed.
- Verified a CJK-heavy filename remains within 245 UTF-8 bytes including `.epub`.
- Ran JavaScript syntax and diff-whitespace checks.