### PR TITLE
Add transfer queue for X4 uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A browser extension to send long-form articles from the web directly to your **Xteink X4** e-ink reader as clean EPUB files.
 
-> Status: **Stable (v1.2.1)** — Tested with Xteink X4
+> Status: **Stable (v1.2.2)** — Tested with Xteink X4
 >
 > Supports: **Chrome** • **Firefox** • **Edge**
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A browser extension to send long-form articles from the web directly to your **Xteink X4** e-ink reader as clean EPUB files.
 
-> Status: **Stable (v1.1.1)** — Tested with Xteink X4
+> Status: **Stable (v1.2.1)** — Tested with Xteink X4
 >
 > Supports: **Chrome** • **Firefox** • **Edge**
 
@@ -39,6 +39,9 @@ It is designed for people who:
   - 💾 **Offline-first & local** — No accounts, no servers, no tracking
   - 📥 **EPUB download fallback** — Keep a local copy if needed
   - 🗂️ **Advanced File Management** — View, sort, and delete files directly on the device
+  - 🗂️ **Transfer Queue** — Save article snapshots and compatible local files while online, then send them together after joining X4 WiFi
+  - 📦 **Local File Transfer** — Send existing `.epub`, `.txt`, and `.xtc` files unchanged
+  - 📅 **Optional Date Folders** — Keep future uploads in daily subfolders under `send-to-x4/`
   
   ---
   
@@ -94,6 +97,14 @@ It is designed for people who:
   2. ✅ Switch to the X4 WiFi hotspot  
   3. ✅ Open the popup and send  
   4. ❌ Do not refresh the page while connected to the X4 hotspot
+
+### Transfer Queue
+
+Use **Queue** while browsing on normal internet WiFi. The extension stores a local article snapshot, so it does not need to re-fetch the source after you connect to the X4 hotspot. You can also add existing EPUB, TXT, and XTC files with **Add files**; imported files are transferred unchanged.
+
+When ready, join the X4 WiFi and click **Send all**. Keep the popup open during a batch transfer. Failed items remain in the local queue and can be retried; queued uploads never fall back to a browser download.
+
+Enable **Organize new uploads by date** in Settings to place new files in `send-to-x4/YYYY-MM-DD/`. It is off by default and existing flat files remain untouched.
   
   ---
   

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A browser extension to send long-form articles from the web directly to your **Xteink X4** e-ink reader as clean EPUB files.
 
-> Status: **Stable (v1.2.2)** — Tested with Xteink X4
+> Status: **Stable (v1.2.3)** — Tested with Xteink X4
 >
 > Supports: **Chrome** • **Firefox** • **Edge**
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Send to X4",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "author": "Xatpy",
   "description": "Send articles from any website to Xteink X4 e-ink reader as EPUB",
   "permissions": [

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Send to X4",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "author": "Xatpy",
   "description": "Send articles from any website to Xteink X4 e-ink reader as EPUB",
   "permissions": [

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Send to X4",
-  "version": "1.1.1",
+  "version": "1.2.1",
   "author": "Xatpy",
   "description": "Send articles from any website to Xteink X4 e-ink reader as EPUB",
   "permissions": [
@@ -23,6 +23,7 @@
       "src/epub/jszip.min.js",
       "src/utils/logger.js",
       "src/utils/sanitize.js",
+      "src/utils/transfer_utils.js",
       "src/epub/epub_templates.js",
       "src/epub/epub_builder.js",
       "src/upload/x4_upload_tab.js",

--- a/manifest.json
+++ b/manifest.json
@@ -18,20 +18,7 @@
     "<all_urls>"
   ],
   "background": {
-    "service_worker": "src/background/service_worker.js",
-    "scripts": [
-      "src/epub/jszip.min.js",
-      "src/utils/logger.js",
-      "src/utils/sanitize.js",
-      "src/utils/transfer_utils.js",
-      "src/utils/folder_path.js",
-      "src/epub/epub_templates.js",
-      "src/epub/epub_builder.js",
-      "src/upload/x4_upload_tab.js",
-      "src/upload/crosspoint_upload.js",
-      "src/utils/settings.js",
-      "src/background/service_worker.js"
-    ]
+    "service_worker": "src/background/service_worker.js"
   },
   "content_scripts": [
     {

--- a/src/background/service_worker.js
+++ b/src/background/service_worker.js
@@ -3,15 +3,8 @@
  * Handles EPUB generation, X4 upload, and download fallback
  */
 
-// Cross-browser compatibility
-// Cross-browser compatibility
-// browserAPI is defined in settings.js, which is loaded before this script in manifest.json
-// const browserAPI = typeof browser !== 'undefined' ? browser : chrome;
-
-// Import required modules (paths relative to service worker location in src/background/)
-// Import required modules
-// Note: In Firefox 'scripts' (Background Page), these are loaded via manifest.json.
-// In Chrome 'service_worker', importScripts works and is required.
+// `background.scripts` is a Manifest V2 field. Load the worker's dependencies
+// explicitly so the same Manifest V3 package works in Chrome and Firefox.
 if (typeof importScripts === 'function') {
     try {
         importScripts(

--- a/src/background/service_worker.js
+++ b/src/background/service_worker.js
@@ -348,38 +348,20 @@ function readQueuedItem(id) {
 }
 
 /**
- * Download EPUB as fallback
- * Chrome MV3 service workers: Use data URL (can't use createObjectURL)
- * Firefox MV3 service workers: Use Blob URL (data URLs blocked for security)
+ * Download EPUB as a base64 data URL. Service workers cannot create object
+ * URLs, so this path works consistently in Chrome and Firefox.
  */
 async function downloadEpubFallback(arrayBuffer, filename) {
     try {
         console.log('[X4 SW] Triggering download fallback...');
-
-        // Detect if we're in Firefox (has 'browser' namespace) or Chrome
-        const isFirefox = typeof browser !== 'undefined' && typeof browser.runtime !== 'undefined';
-        console.log('[X4 SW] Browser detected:', isFirefox ? 'Firefox' : 'Chrome');
-
-        let downloadUrl;
-
-        if (isFirefox) {
-            // Firefox: Use Blob URL (works in MV3 service workers)
-            console.log('[X4 SW] Using Blob URL for Firefox...');
-            const blob = new Blob([arrayBuffer], { type: 'application/epub+zip' });
-            downloadUrl = URL.createObjectURL(blob);
-            console.log('[X4 SW] Blob URL created:', downloadUrl);
-        } else {
-            // Chrome: Use data URL (works in service workers)
-            console.log('[X4 SW] Converting to data URL for Chrome...');
-            const bytes = new Uint8Array(arrayBuffer);
-            let binary = '';
-            for (let i = 0; i < bytes.length; i++) {
-                binary += String.fromCharCode(bytes[i]);
-            }
-            const base64 = btoa(binary);
-            downloadUrl = `data:application/epub+zip;base64,${base64}`;
-            console.log('[X4 SW] Data URL length:', downloadUrl.length);
+        const bytes = new Uint8Array(arrayBuffer);
+        let binary = '';
+        for (let i = 0; i < bytes.length; i++) {
+            binary += String.fromCharCode(bytes[i]);
         }
+        const base64 = btoa(binary);
+        const downloadUrl = `data:application/epub+zip;base64,${base64}`;
+        console.log('[X4 SW] Data URL length:', downloadUrl.length);
 
         // Trigger download
         console.log('[X4 SW] Calling browserAPI.downloads.download...');
@@ -390,15 +372,6 @@ async function downloadEpubFallback(arrayBuffer, filename) {
         });
 
         console.log('[X4 SW] Download triggered successfully, ID:', downloadId);
-
-        // Clean up Blob URL after download starts (Firefox only)
-        if (isFirefox) {
-            // Give the download a moment to start before revoking
-            setTimeout(() => {
-                URL.revokeObjectURL(downloadUrl);
-                console.log('[X4 SW] Blob URL revoked');
-            }, 1000);
-        }
     } catch (error) {
         console.error('[X4 SW] Download failed:', error);
         throw error;

--- a/src/background/service_worker.js
+++ b/src/background/service_worker.js
@@ -18,6 +18,7 @@ if (typeof importScripts === 'function') {
             '../epub/jszip.min.js',
             '../utils/logger.js',
             '../utils/sanitize.js',
+            '../utils/transfer_utils.js',
             '../epub/epub_templates.js',
             '../epub/epub_builder.js',
             '../upload/x4_upload_tab.js',
@@ -50,6 +51,11 @@ browserAPI.runtime.onMessage.addListener((message, sender, sendResponse) => {
                 success: false,
                 error: error.message
             }));
+        return true;
+    }
+
+    if (message.type === 'X4_UPLOAD_QUEUE_ITEM') {
+        handleUploadQueueItem(message, sendResponse);
         return true;
     }
 
@@ -289,6 +295,54 @@ async function handleSendArticle(messageData, sender, sendResponse) {
             error: error.message
         });
     }
+}
+
+/** Queue uploads intentionally do not download a fallback file on failure. */
+async function handleUploadQueueItem(messageData, sendResponse) {
+    try {
+        const { itemId, targetDirectory, filename } = messageData.payload;
+        const item = await readQueuedItem(itemId);
+        if (!item) throw new Error('This queue item is no longer available locally.');
+        const settings = messageData.settings || {};
+        const isCrosspoint = settings.firmwareType === 'crosspoint';
+        const uploader = isCrosspoint ? CrossPointUpload : X4UploadTab;
+        const deviceIp = settings.deviceIp || (isCrosspoint ? '192.168.4.1' : '192.168.3.3');
+        uploader.setIp(deviceIp);
+        let data;
+        let name = filename || item.filename;
+        let mimeType = item.mimeType;
+        if (item.kind === 'article') {
+            const epub = await EpubBuilder.build(item.article);
+            data = await EpubBuilder.blobToArrayBuffer(epub);
+            name = filename || EpubBuilder.generateFilename(item.article);
+            mimeType = 'application/epub+zip';
+        } else {
+            data = await item.blob.arrayBuffer();
+        }
+        const result = await uploader.uploadFile({ data, filename: name, mimeType, targetDirectory });
+        sendResponse(result);
+    } catch (error) {
+        sendResponse({ success: false, error: error.message || 'Transfer failed.' });
+    }
+}
+
+/**
+ * Runtime messages are JSON-serialized in Chrome, so a queued Blob cannot be
+ * passed from the popup to this worker. Read it from the shared extension
+ * IndexedDB database instead.
+ */
+function readQueuedItem(id) {
+    return new Promise((resolve, reject) => {
+        const request = indexedDB.open('send-to-x4-transfer-queue', 1);
+        request.onerror = () => reject(request.error || new Error('Could not read the local transfer queue.'));
+        request.onsuccess = () => {
+            const db = request.result;
+            const transaction = db.transaction('items', 'readonly');
+            const getRequest = transaction.objectStore('items').get(id);
+            getRequest.onsuccess = () => { db.close(); resolve(getRequest.result || null); };
+            getRequest.onerror = () => { db.close(); reject(getRequest.error || new Error('Could not read the queued item.')); };
+        };
+    });
 }
 
 /**

--- a/src/popup/modules/file_manager.js
+++ b/src/popup/modules/file_manager.js
@@ -1,6 +1,10 @@
 // Cross-browser compatibility
 const browserAPI = typeof browser !== 'undefined' ? browser : chrome;
 
+// TransferUtils is loaded as a classic popup script so the same validation is
+// available to the service worker through importScripts.
+const MAX_SCANNED_DIRECTORIES = 200;
+
 /**
  * File Manager
  * Handles device communication (X4 standard and CrossPoint firmware)
@@ -94,23 +98,35 @@ export class FileManager {
      * @returns {Promise<Array>}
      */
     async loadFolderFiles(settings, sortOrder = 'newest') {
+        this.lastLoadError = null;
         try {
             const isCrosspoint = settings.firmwareType === 'crosspoint';
             const ip = settings.deviceIp;
             const baseUrl = `http://${ip}`;
 
-            let listUrl, epubFiles;
-
-            if (isCrosspoint) {
-                listUrl = `${baseUrl}/api/files?path=/${this.TARGET_FOLDER}`;
+            const allowed = new Set(['.epub', '.txt', '.xtc']);
+            const pending = [this.TARGET_FOLDER];
+            const visited = new Set();
+            let epubFiles = [];
+            while (pending.length) {
+                if (visited.size >= MAX_SCANNED_DIRECTORIES) {
+                    const error = new Error(`Stopped after scanning ${MAX_SCANNED_DIRECTORIES} folders under ${this.TARGET_FOLDER}.`);
+                    error.code = 'SCAN_LIMIT';
+                    throw error;
+                }
+                const folder = pending.shift();
+                if (visited.has(folder)) continue;
+                visited.add(folder);
+                const listUrl = isCrosspoint ? `${baseUrl}/api/files?path=${encodeURIComponent('/' + folder)}` : `${baseUrl}/list?dir=${encodeURIComponent('/' + folder + '/')}`;
                 const response = await this.bgFetch(listUrl);
                 const files = await response.json();
-                epubFiles = files.filter(f => !f.isDirectory && f.name.endsWith('.epub'));
-            } else {
-                listUrl = `${baseUrl}/list?dir=/${this.TARGET_FOLDER}/`;
-                const response = await this.bgFetch(listUrl);
-                const files = await response.json();
-                epubFiles = files.filter(f => f.type === 'file' && f.name.endsWith('.epub'));
+                if (!Array.isArray(files)) continue;
+                for (const file of files) {
+                    const isDirectory = isCrosspoint ? file.isDirectory === true || file.type === 'dir' : file.type === 'dir';
+                    if (isDirectory) { pending.push(`${folder}/${file.name}`); continue; }
+                    const ext = file.name.slice(file.name.lastIndexOf('.')).toLowerCase();
+                    if (allowed.has(ext)) epubFiles.push({ ...file, folder });
+                }
             }
 
             // Enrich with parsed date for sorting
@@ -138,6 +154,7 @@ export class FileManager {
             return epubFiles;
         } catch (error) {
             console.error('[File Manager] Error loading folder:', error);
+            if (error.code === 'SCAN_LIMIT') this.lastLoadError = error.message;
             return []; // Return empty on error (folder might not exist)
         }
     }
@@ -165,12 +182,13 @@ export class FileManager {
      * @param {Object} settings 
      * @returns {Promise<boolean>}
      */
-    async deleteFile(filename, settings) {
+    async deleteFile(file, settings) {
         try {
-            console.log('[File Manager] Deleting file:', filename);
+            const filename = TransferUtils.safeFilename(typeof file === 'string' ? file : file.name);
             const isCrosspoint = settings.firmwareType === 'crosspoint';
             const ip = settings.deviceIp;
-            const fullPath = `/${this.TARGET_FOLDER}/${filename}`;
+            const folder = TransferUtils.safeDirectory(typeof file === 'string' ? this.TARGET_FOLDER : file.folder);
+            const fullPath = `/${folder}/${filename}`;
 
             // Use URLSearchParams instead of FormData for message safety
             const params = new URLSearchParams();

--- a/src/popup/modules/main.js
+++ b/src/popup/modules/main.js
@@ -1,6 +1,7 @@
 import { UIManager } from './ui_manager.js';
 import { FileManager } from './file_manager.js';
 import { ArticleManager } from './article_manager.js';
+import { addArticle, addFiles, listQueue, removeItem, updateItem, recoverInterruptedItems } from '../../queue/queue_store.js';
 
 // Cross-browser compatibility
 const browserAPI = typeof browser !== 'undefined' ? browser : chrome;
@@ -15,6 +16,9 @@ class PopupController {
         this.articleManager = new ArticleManager();
         this.settings = { firmwareType: 'stock', deviceIp: '192.168.3.3', settingsPanelOpen: false };
         this.currentSort = 'newest'; // Default sort
+        this.queueItems = [];
+        this.sendingQueue = false;
+        this.stopQueueRequested = false;
     }
 
     async init() {
@@ -25,6 +29,11 @@ class PopupController {
         this.ui.setupListeners({
             onSend: () => this.handleSend(),
             onDownload: () => this.handleDownload(),
+            onQueueArticle: () => this.handleQueueArticle(),
+            onImportFiles: (event) => this.handleImportFiles(event),
+            onSendAll: () => this.handleSendAll(),
+            onStopQueue: () => { this.stopQueueRequested = true; this.ui.setQueueProgress('Stopping after the current transfer…'); },
+            onOrganizeByDate: (event) => this.handleOrganizeByDate(event),
             onSettingsChange: (e) => this.handleSettingsChange(e),
             onIpChange: (e) => this.handleIpChange(e),
             onConnect: () => this.handleConnect(),
@@ -50,9 +59,11 @@ class PopupController {
         });
 
         // Run checks in parallel
+        await recoverInterruptedItems();
         await Promise.all([
             this.checkArticle(),
-            this.checkDevice()
+            this.checkDevice(),
+            this.refreshQueue()
         ]);
     }
 
@@ -113,7 +124,7 @@ class PopupController {
 
             // Load files
             const files = await this.fileManager.loadFolderFiles(this.settings);
-            this.ui.showFileList(files, (filename, li) => this.handleDelete(filename, li));
+            this.ui.showFileList(files, (filename, li) => this.handleDelete(filename, li), this.fileManager.lastLoadError);
 
             if (force) this.ui.setConnectButtonState('success');
             return true;
@@ -184,7 +195,101 @@ class PopupController {
         }
     }
 
-    async handleDelete(filename, liElement) {
+    async handleOrganizeByDate(event) {
+        this.settings.organizeByDate = event.target.checked;
+        await window.Settings.setOrganizeByDate(this.settings.organizeByDate);
+    }
+
+    async refreshQueue() {
+        this.queueItems = await listQueue();
+        this.ui.showQueue(this.queueItems, {
+            sending: this.sendingQueue,
+            onSendItem: item => this.sendQueueItem(item),
+            onRemoveItem: item => this.handleRemoveQueueItem(item)
+        });
+    }
+
+    async handleQueueArticle() {
+        if (!this.articleManager.articleData) return;
+        try {
+            await addArticle(this.articleManager.articleData);
+            await this.refreshQueue();
+            this.ui.setQueueProgress('Article added to the local queue.');
+        } catch (error) {
+            this.ui.setQueueProgress(error.message);
+        }
+    }
+
+    async handleImportFiles(event) {
+        try {
+            const files = Array.from(event.target.files || []);
+            if (files.length) await addFiles(files);
+            await this.refreshQueue();
+            this.ui.setQueueProgress(files.length ? `${files.length} file${files.length === 1 ? '' : 's'} added to the queue.` : '');
+        } catch (error) {
+            this.ui.setQueueProgress(error.message);
+        } finally {
+            event.target.value = '';
+        }
+    }
+
+    async handleRemoveQueueItem(item) {
+        if (!confirm(`Remove "${item.displayName}" from the local queue?`)) return;
+        await removeItem(item.id);
+        await this.refreshQueue();
+    }
+
+    async handleSendAll() {
+        this.sendingQueue = true;
+        this.stopQueueRequested = false;
+        try {
+            for (const item of [...this.queueItems]) {
+                const result = await this.sendQueueItem(item, true);
+                if (!result.success && result.connectivityFailure) {
+                    this.ui.setQueueProgress('Connection to X4 was lost. Remaining items are still queued.');
+                    break;
+                }
+                if (this.stopQueueRequested) break;
+            }
+        } finally {
+            this.sendingQueue = false;
+            await this.refreshQueue();
+        }
+    }
+
+    async sendQueueItem(item, batch = false) {
+        if (this.sendingQueue && !batch) return;
+        if (!batch) this.sendingQueue = true;
+        const position = this.queueItems.findIndex(candidate => candidate.id === item.id) + 1;
+        const current = { ...item, status: 'sending', lastError: null, attempts: (item.attempts || 0) + 1, lastAttemptAt: new Date().toISOString() };
+        await updateItem(current);
+        await this.refreshQueue();
+        this.ui.setQueueProgress(`Sending ${position} of ${this.queueItems.length}: ${item.displayName}`);
+        try {
+            const targetDirectory = TransferUtils.destination('send-to-x4', this.settings.organizeByDate, item.contentDate || item.createdAt);
+            const response = await browserAPI.runtime.sendMessage({ type: 'X4_UPLOAD_QUEUE_ITEM', payload: { itemId: current.id, targetDirectory }, settings: { firmwareType: this.settings.firmwareType, deviceIp: this.settings.deviceIp } });
+            if (!response?.success) throw new Error(response?.error || 'Upload failed.');
+            await removeItem(item.id);
+            this.ui.setQueueProgress(`Sent: ${item.displayName}`);
+            await this.refreshQueue();
+            if (!batch) await this.checkDevice();
+            return { success: true, connectivityFailure: false };
+        } catch (error) {
+            const message = error.message || 'Upload failed.';
+            await updateItem({ ...current, status: 'failed', lastError: message });
+            this.ui.setQueueProgress(`Failed: ${message}`);
+            await this.refreshQueue();
+            return { success: false, connectivityFailure: TransferUtils.isConnectivityError(message) };
+        } finally {
+            if (!batch) {
+                this.sendingQueue = false;
+                await this.refreshQueue();
+            }
+        }
+    }
+
+    async handleDelete(file, liElement) {
+        const filename = typeof file === 'string' ? file : file.name;
         if (!confirm(`Delete "${filename}" from X4?`)) return;
 
         liElement.classList.add('deleting'); // UI optimistically? UIManager should handle this ideally but we passed liElement
@@ -192,7 +297,7 @@ class PopupController {
         // We can access properties on liElement directly since it's a DOM node passed back.
 
         try {
-            await this.fileManager.deleteFile(filename, this.settings);
+            await this.fileManager.deleteFile(file, this.settings);
             // On success, remove from UI
             liElement.remove();
 

--- a/src/popup/modules/main.js
+++ b/src/popup/modules/main.js
@@ -19,6 +19,7 @@ class PopupController {
         this.queueItems = [];
         this.sendingQueue = false;
         this.stopQueueRequested = false;
+        this.deviceConnected = false;
     }
 
     async init() {
@@ -38,6 +39,7 @@ class PopupController {
             onIpChange: (e) => this.handleIpChange(e),
             onTargetFolderChange: (e) => this.handleTargetFolderChange(e),
             onConnect: () => this.handleConnect(),
+            onRefreshDevice: () => this.handleDeviceRefresh(),
             onSettingsToggle: () => this.handleSettingsToggle(),
             onSortChange: (e) => this.handleSortChange(e)
         });
@@ -123,6 +125,7 @@ class PopupController {
         const result = await this.fileManager.checkDevice(this.settings);
 
         if (result.connected) {
+            this.deviceConnected = true;
             this.ui.showDeviceConnected(this.settings.deviceIp);
 
             // Load files
@@ -132,6 +135,7 @@ class PopupController {
             if (force) this.ui.setConnectButtonState('success');
             return true;
         } else {
+            this.deviceConnected = false;
             this.ui.showDeviceDisconnected();
             if (force) this.ui.setConnectButtonState('error');
             return false;
@@ -206,6 +210,15 @@ class PopupController {
         }
 
         await this.checkDevice(true);
+    }
+
+    async handleDeviceRefresh() {
+        this.ui.setDeviceRefreshState(true);
+        try {
+            await this.checkDevice();
+        } finally {
+            this.ui.setDeviceRefreshState(false);
+        }
     }
 
     async handleSortChange(event) {
@@ -344,7 +357,7 @@ class PopupController {
 
     async handleSend() {
         const article = this.articleManager.articleData;
-        if (!article) return;
+        if (!article || !this.deviceConnected) return;
 
         const uiSettings = this.ui.getSettingsFromUI();
         if (uiSettings.targetFolder && uiSettings.targetFolder !== this.settings.targetFolder) {

--- a/src/popup/modules/ui_manager.js
+++ b/src/popup/modules/ui_manager.js
@@ -5,6 +5,8 @@
 export class UIManager {
     constructor() {
         this.elements = {};
+        this.deviceConnected = false;
+        this.sendInProgress = false;
         this.cacheElements();
     }
 
@@ -30,7 +32,9 @@ export class UIManager {
             organizeByDate: document.getElementById('organize-by-date'),
             deviceLoading: document.getElementById('device-loading'),
             deviceConnected: document.getElementById('device-connected'),
+            deviceConnectedLabel: document.getElementById('device-connected-label'),
             deviceDisconnected: document.getElementById('device-disconnected'),
+            deviceRefreshBtn: document.getElementById('device-refresh-btn'),
             deviceFiles: document.getElementById('device-files'),
             fileCount: document.getElementById('file-count'),
             fileListItems: document.getElementById('file-list-items'),
@@ -59,6 +63,7 @@ export class UIManager {
         if (handlers.onIpChange) this.elements.deviceIpInput.addEventListener('change', handlers.onIpChange);
         if (handlers.onTargetFolderChange) this.elements.targetFolderInput.addEventListener('change', handlers.onTargetFolderChange);
         if (handlers.onConnect) this.elements.connectBtn.addEventListener('click', handlers.onConnect);
+        if (handlers.onRefreshDevice) this.elements.deviceRefreshBtn.addEventListener('click', handlers.onRefreshDevice);
         if (handlers.onSettingsToggle) this.elements.settingsHeader.addEventListener('click', handlers.onSettingsToggle);
         if (handlers.onSortChange) this.elements.sortSelect.addEventListener('change', handlers.onSortChange);
     }
@@ -111,10 +116,8 @@ export class UIManager {
         this.elements.deviceConnected.classList.remove('hidden');
 
         // Update the displayed IP address
-        const ipDisplay = this.elements.deviceConnected.querySelector('span:last-child');
-        if (ipDisplay) {
-            ipDisplay.textContent = `Connected to ${ip}`;
-        }
+        this.elements.deviceConnectedLabel.textContent = `Connected to ${ip}`;
+        this.setSendAvailability(true);
     }
 
     showDeviceDisconnected() {
@@ -122,6 +125,18 @@ export class UIManager {
         this.elements.deviceConnected.classList.add('hidden');
         this.elements.deviceFiles.classList.add('hidden');
         this.elements.deviceDisconnected.classList.remove('hidden');
+        this.setSendAvailability(false);
+    }
+
+    setSendAvailability(connected) {
+        this.deviceConnected = connected;
+        this.elements.sendBtn.disabled = !connected || this.sendInProgress;
+    }
+
+    setDeviceRefreshState(refreshing) {
+        const btn = this.elements.deviceRefreshBtn;
+        btn.disabled = refreshing;
+        btn.innerHTML = refreshing ? '<span class="btn-spinner"></span>' : '↻';
     }
 
     showFileList(files, onDelete, errorMessage = null) {
@@ -253,13 +268,15 @@ export class UIManager {
 
         switch (state) {
             case 'sending':
+                this.sendInProgress = true;
                 btn.disabled = true;
                 iconSpan.innerHTML = '<div class="btn-spinner"></div>';
                 textSpan.textContent = 'Sending...';
                 break;
 
             case 'success':
-                btn.disabled = false;
+                this.sendInProgress = false;
+                btn.disabled = !this.deviceConnected;
                 btn.classList.add('success');
                 iconSpan.textContent = '✅';
                 textSpan.textContent = message || 'Sent!';
@@ -267,7 +284,8 @@ export class UIManager {
                 break;
 
             case 'error':
-                btn.disabled = false;
+                this.sendInProgress = false;
+                btn.disabled = !this.deviceConnected;
                 btn.classList.add('error');
                 iconSpan.textContent = '❌';
                 textSpan.textContent = message || 'Failed';
@@ -275,7 +293,8 @@ export class UIManager {
                 break;
 
             default:
-                btn.disabled = false;
+                this.sendInProgress = false;
+                btn.disabled = !this.deviceConnected;
                 iconSpan.textContent = '📖';
                 textSpan.textContent = 'Send to X4';
                 break;

--- a/src/popup/modules/ui_manager.js
+++ b/src/popup/modules/ui_manager.js
@@ -20,6 +20,14 @@ export class UIManager {
             errorMessage: document.getElementById('error-message'),
             sendBtn: document.getElementById('send-btn'),
             downloadBtn: document.getElementById('download-btn'),
+            queueArticleBtn: document.getElementById('queue-article-btn'),
+            importFiles: document.getElementById('import-files'),
+            sendAllBtn: document.getElementById('send-all-btn'),
+            stopQueueBtn: document.getElementById('stop-queue-btn'),
+            queueCount: document.getElementById('queue-count'),
+            queueItems: document.getElementById('queue-items'),
+            queueProgress: document.getElementById('queue-progress'),
+            organizeByDate: document.getElementById('organize-by-date'),
             deviceLoading: document.getElementById('device-loading'),
             deviceConnected: document.getElementById('device-connected'),
             deviceDisconnected: document.getElementById('device-disconnected'),
@@ -41,6 +49,11 @@ export class UIManager {
     setupListeners(handlers) {
         if (handlers.onSend) this.elements.sendBtn.addEventListener('click', handlers.onSend);
         if (handlers.onDownload) this.elements.downloadBtn.addEventListener('click', handlers.onDownload);
+        if (handlers.onQueueArticle) this.elements.queueArticleBtn.addEventListener('click', handlers.onQueueArticle);
+        if (handlers.onImportFiles) this.elements.importFiles.addEventListener('change', handlers.onImportFiles);
+        if (handlers.onSendAll) this.elements.sendAllBtn.addEventListener('click', handlers.onSendAll);
+        if (handlers.onStopQueue) this.elements.stopQueueBtn.addEventListener('click', handlers.onStopQueue);
+        if (handlers.onOrganizeByDate) this.elements.organizeByDate.addEventListener('change', handlers.onOrganizeByDate);
         if (handlers.onSettingsChange) this.elements.firmwareTypeSelect.addEventListener('change', handlers.onSettingsChange);
         if (handlers.onIpChange) this.elements.deviceIpInput.addEventListener('change', handlers.onIpChange);
         if (handlers.onConnect) this.elements.connectBtn.addEventListener('click', handlers.onConnect);
@@ -109,32 +122,27 @@ export class UIManager {
         this.elements.deviceDisconnected.classList.remove('hidden');
     }
 
-    showFileList(files, onDelete) {
+    showFileList(files, onDelete, errorMessage = null) {
         this.elements.deviceFiles.classList.remove('hidden');
         this.elements.fileCount.textContent = `${files.length} file${files.length !== 1 ? 's' : ''}`;
 
         if (files.length === 0) {
-            this.elements.fileListItems.innerHTML = '<li class="empty"><span class="file-name">No files yet</span></li>';
+            const item = document.createElement('li');
+            item.className = 'empty';
+            const message = document.createElement('span');
+            message.className = 'file-name';
+            message.textContent = errorMessage || 'No files yet';
+            item.append(message);
+            this.elements.fileListItems.replaceChildren(item);
         } else {
             // No slicing - show all files (CSS handles scroll)
-            this.elements.fileListItems.innerHTML = files
-                .map(f => {
-                    const escapedName = f.name.replace(/"/g, '&quot;');
-                    return `<li data-filename="${escapedName}">
-                    <span class="file-name" title="${escapedName}">${f.name}</span>
-                    <button class="delete-btn" title="Delete file">🗑️</button>
-                </li>`;
-                })
-                .join('');
-
-            // Add click handlers for delete buttons
-            this.elements.fileListItems.querySelectorAll('.delete-btn').forEach(btn => {
-                btn.addEventListener('click', (e) => {
-                    e.stopPropagation();
-                    const li = btn.closest('li');
-                    const filename = li.dataset.filename;
-                    onDelete(filename, li);
-                });
+            this.elements.fileListItems.replaceChildren();
+            files.forEach(file => {
+                const li = document.createElement('li');
+                const name = document.createElement('span'); name.className = 'file-name'; name.title = file.folder ? `${file.folder}/${file.name}` : file.name; name.textContent = file.folder ? `${file.folder}/${file.name}` : file.name;
+                const remove = document.createElement('button'); remove.className = 'delete-btn'; remove.title = 'Delete file'; remove.textContent = '🗑️';
+                remove.addEventListener('click', e => { e.stopPropagation(); onDelete(file, li); });
+                li.append(name, remove); this.elements.fileListItems.append(li);
             });
         }
     }
@@ -145,6 +153,31 @@ export class UIManager {
         this.elements.fileListItems.innerHTML = '<li class="empty"><span class="file-name">No files yet</span></li>';
     }
 
+    showQueue(items, handlers = {}) {
+        const total = items.reduce((sum, item) => sum + (item.size || 0), 0);
+        this.elements.queueCount.textContent = `${items.length} item${items.length === 1 ? '' : 's'} · ${this.formatBytes(total)}`;
+        this.elements.sendAllBtn.disabled = items.length === 0 || !!handlers.sending;
+        this.elements.stopQueueBtn.classList.toggle('hidden', !handlers.sending);
+        this.elements.queueItems.replaceChildren();
+        if (!items.length) {
+            const empty = document.createElement('li'); empty.className = 'empty'; empty.textContent = 'No queued transfers yet'; this.elements.queueItems.append(empty); return;
+        }
+        for (const item of items) {
+            const row = document.createElement('li');
+            const name = document.createElement('span'); name.className = 'file-name'; name.textContent = item.displayName;
+            const status = item.status === 'failed' ? this.truncateQueueError(item.lastError) : item.status;
+            const meta = document.createElement('small'); meta.className = 'queue-meta'; meta.textContent = `${item.kind === 'article' ? 'Article' : item.filename} · ${status}`;
+            const details = document.createElement('div'); details.className = 'queue-details'; details.append(name, meta);
+            const send = document.createElement('button'); send.className = 'queue-btn'; send.textContent = item.status === 'failed' ? 'Retry' : 'Send'; send.disabled = !!handlers.sending; send.addEventListener('click', () => handlers.onSendItem?.(item));
+            const remove = document.createElement('button'); remove.className = 'delete-btn'; remove.textContent = '🗑️'; remove.disabled = !!handlers.sending; remove.addEventListener('click', () => handlers.onRemoveItem?.(item));
+            row.append(details, send, remove); this.elements.queueItems.append(row);
+        }
+    }
+
+    setQueueProgress(message = '') { this.elements.queueProgress.textContent = message; this.elements.queueProgress.classList.toggle('hidden', !message); }
+    formatBytes(bytes) { return bytes < 1024 * 1024 ? `${Math.ceil(bytes / 1024)} KB` : `${(bytes / (1024 * 1024)).toFixed(1)} MB`; }
+    truncateQueueError(error) { const value = String(error || 'Upload failed.'); return value.length > 96 ? `${value.slice(0, 93)}…` : value; }
+
     // --- Settings UI ---
 
     // --- Settings UI ---
@@ -152,6 +185,7 @@ export class UIManager {
     updateSettingsUI(settings) {
         this.elements.firmwareTypeSelect.value = settings.firmwareType;
         this.elements.deviceIpInput.value = settings.deviceIp;
+        this.elements.organizeByDate.checked = !!settings.organizeByDate;
         // Optional: Update placeholder based on firmware type (UX improvement)
         if (settings.firmwareType === 'crosspoint') {
             this.elements.deviceIpInput.placeholder = '192.168.4.1';

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -408,6 +408,15 @@ body {
     content: '';
 }
 
+.queue-hint { margin: -4px 0 10px; }
+.queue-actions { margin-bottom: 10px; }
+.queue-items { max-height: 180px; }
+.queue-details { flex: 1; min-width: 0; display: flex; flex-direction: column; }
+.queue-meta { color: #71717a; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.queue-btn { background: #3f3f46; border: 0; border-radius: 4px; color: #e4e4e7; cursor: pointer; font-size: 11px; padding: 4px 7px; }
+.queue-btn:disabled { opacity: .5; }
+.checkbox-option { color: #a1a1aa; cursor: pointer; display: block; font-size: 12px; }
+
 /* Settings Section */
 .section-header.clickable {
     cursor: pointer;

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -269,6 +269,43 @@ body {
     color: #a1a1aa;
 }
 
+.device-refresh-btn {
+    margin-left: auto;
+    width: 28px;
+    height: 28px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border: 1px solid #3f3f46;
+    border-radius: 6px;
+    background: #27272a;
+    color: #a1a1aa;
+    cursor: pointer;
+    font-size: 18px;
+    line-height: 1;
+    transition: all 0.2s ease;
+}
+
+.device-refresh-btn:hover:not(:disabled) {
+    background: #3f3f46;
+    color: #e4e4e7;
+    border-color: #52525b;
+}
+
+.device-refresh-btn:disabled {
+    cursor: wait;
+    opacity: 0.7;
+}
+
+.device-refresh-btn .btn-spinner {
+    width: 13px;
+    height: 13px;
+    border: 2px solid rgba(255, 255, 255, 0.3);
+    border-top-color: white;
+    border-radius: 50%;
+    animation: spin 0.8s linear infinite;
+}
+
 .status-indicator {
     width: 8px;
     height: 8px;

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -159,7 +159,7 @@
 
     <!-- Footer -->
     <footer class="popup-footer">
-      <a href="https://github.com/Xatpy/send-to-x4" target="_blank" class="footer-link">v1.2.2</a>
+      <a href="https://github.com/Xatpy/send-to-x4" target="_blank" class="footer-link">v1.2.3</a>
     </footer>
   </div>
 

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -31,7 +31,7 @@
           <span id="article-words" class="meta-words">— words</span>
         </div>
         <div class="button-group">
-          <button id="send-btn" class="send-btn primary">
+          <button id="send-btn" class="send-btn primary" disabled>
             <span class="btn-icon">📖</span>
             <span class="btn-text">Send to X4</span>
           </button>
@@ -90,7 +90,8 @@
 
       <div id="device-connected" class="device-status hidden">
         <div class="status-indicator connected"></div>
-        <span>Connected to 192.168.3.3</span>
+        <span id="device-connected-label">Connected to 192.168.3.3</span>
+        <button id="device-refresh-btn" class="device-refresh-btn" type="button" title="Refresh device status" aria-label="Refresh device status">↻</button>
       </div>
 
       <div id="device-disconnected" class="device-status hidden">

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -159,7 +159,7 @@
 
     <!-- Footer -->
     <footer class="popup-footer">
-      <a href="https://github.com/Xatpy/send-to-x4" target="_blank" class="footer-link">v1.2.1</a>
+      <a href="https://github.com/Xatpy/send-to-x4" target="_blank" class="footer-link">v1.2.2</a>
     </footer>
   </div>
 

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -39,6 +39,10 @@
             <span class="btn-icon">📥</span>
             <span class="btn-text">Download</span>
           </button>
+          <button id="queue-article-btn" class="send-btn secondary">
+            <span class="btn-icon">➕</span>
+            <span class="btn-text">Queue</span>
+          </button>
         </div>
       </div>
 
@@ -55,6 +59,21 @@
     </section>
 
     <!-- Divider -->
+    <div class="divider"></div>
+
+    <section id="queue-section" class="section">
+      <div class="section-header"><span class="section-icon">🗂️</span><span class="section-title">Transfer queue</span><span id="queue-count" class="file-count">0 items</span></div>
+      <p class="hint queue-hint">Add items while online, then keep this popup open while sending them on X4 WiFi.</p>
+      <div class="button-group queue-actions">
+        <label for="import-files" class="send-btn secondary"><span class="btn-icon">📂</span><span class="btn-text">Add files</span></label>
+        <input id="import-files" type="file" accept=".epub,.txt,.xtc" multiple class="hidden">
+        <button id="send-all-btn" class="send-btn primary"><span class="btn-icon">📤</span><span class="btn-text">Send all</span></button>
+        <button id="stop-queue-btn" class="send-btn secondary hidden"><span class="btn-icon">⏹</span><span class="btn-text">Stop</span></button>
+      </div>
+      <div id="queue-progress" class="hint hidden"></div>
+      <ul id="queue-items" class="file-items queue-items"></ul>
+    </section>
+
     <div class="divider"></div>
 
     <!-- Device Section -->
@@ -128,16 +147,18 @@
             </button>
           </div>
         </div>
+        <label class="settings-sub-option checkbox-option"><input type="checkbox" id="organize-by-date"> Organize new uploads by date</label>
       </div>
     </section>
 
     <!-- Footer -->
     <footer class="popup-footer">
-      <a href="https://github.com/Xatpy/send-to-x4" target="_blank" class="footer-link">v1.1.1</a>
+      <a href="https://github.com/Xatpy/send-to-x4" target="_blank" class="footer-link">v1.2.1</a>
     </footer>
   </div>
 
   <script src="../utils/settings.js"></script>
+  <script src="../utils/transfer_utils.js"></script>
   <script type="module" src="modules/main.js"></script>
 </body>
 

--- a/src/queue/queue_store.js
+++ b/src/queue/queue_store.js
@@ -1,0 +1,88 @@
+// TransferUtils is intentionally a popup global: it is also loaded by the
+// service worker through importScripts, which keeps validation identical in both contexts.
+const DB_NAME = 'send-to-x4-transfer-queue';
+const STORE_NAME = 'items';
+export const MAX_FILE_BYTES = 50 * 1024 * 1024;
+export const MAX_QUEUE_BYTES = 200 * 1024 * 1024;
+
+function openDb() {
+    return new Promise((resolve, reject) => {
+        const request = indexedDB.open(DB_NAME, 1);
+        request.onupgradeneeded = () => {
+            const store = request.result.createObjectStore(STORE_NAME, { keyPath: 'id' });
+            store.createIndex('createdAt', 'createdAt');
+            store.createIndex('sourceUrl', 'sourceUrl', { unique: false });
+        };
+        request.onsuccess = () => resolve(request.result);
+        request.onerror = () => reject(request.error || new Error('Could not open the local transfer queue.'));
+    });
+}
+
+async function transaction(mode, operation) {
+    const db = await openDb();
+    return new Promise((resolve, reject) => {
+        const tx = db.transaction(STORE_NAME, mode);
+        const result = operation(tx.objectStore(STORE_NAME));
+        tx.oncomplete = () => { db.close(); resolve(result); };
+        tx.onerror = () => { db.close(); reject(tx.error || new Error('Could not update the transfer queue.')); };
+        tx.onabort = () => { db.close(); reject(tx.error || new Error('Could not update the transfer queue.')); };
+    });
+}
+
+export async function listQueue() {
+    const db = await openDb();
+    return new Promise((resolve, reject) => {
+        const request = db.transaction(STORE_NAME, 'readonly').objectStore(STORE_NAME).getAll();
+        request.onsuccess = () => { db.close(); resolve(request.result.sort((a, b) => a.createdAt.localeCompare(b.createdAt))); };
+        request.onerror = () => { db.close(); reject(request.error); };
+    });
+}
+
+export async function queueUsage() {
+    return (await listQueue()).reduce((total, item) => total + (item.size || 0), 0);
+}
+
+export async function addArticle(article) {
+    const existing = await listQueue();
+    if (article.sourceUrl && existing.some(item => item.kind === 'article' && item.sourceUrl === article.sourceUrl)) {
+        throw new Error('This article is already in the queue.');
+    }
+    const title = String(article.title || 'article').replace(/[\\/:*?"<>|]/g, ' ').replace(/\s+/g, ' ').trim().slice(0, 120) || 'article';
+    const filename = `${title}.epub`;
+    const item = makeItem({ kind: 'article', displayName: article.title || 'Untitled article', filename, mimeType: 'application/epub+zip', sourceUrl: article.sourceUrl, article, size: new Blob([JSON.stringify(article)]).size });
+    await ensureCapacity(item.size);
+    await transaction('readwrite', store => store.put(item));
+    return item;
+}
+
+export async function addFiles(files) {
+    const existing = await listQueue();
+    const added = [];
+    for (const file of files) {
+        const filename = TransferUtils.safeFilename(file.name);
+        if (file.size > MAX_FILE_BYTES) throw new Error(`${filename} is larger than the 50 MB per-file limit.`);
+        const duplicate = [...existing, ...added].some(item => item.kind === 'file' && item.filename === filename && item.size === file.size);
+        if (duplicate) throw new Error(`${filename} is already in the queue.`);
+        const item = makeItem({ kind: 'file', displayName: filename, filename, mimeType: TransferUtils.mimeTypeFor(filename), blob: file, size: file.size });
+        await ensureCapacity(item.size + added.reduce((total, candidate) => total + candidate.size, 0));
+        added.push(item);
+    }
+    await transaction('readwrite', store => added.forEach(item => store.put(item)));
+    return added;
+}
+
+function makeItem(values) {
+    const now = new Date().toISOString();
+    return { schemaVersion: 1, id: crypto.randomUUID ? crypto.randomUUID() : `${Date.now()}-${Math.random()}`, createdAt: now, contentDate: values.article?.date || now.slice(0, 10), attempts: 0, status: 'queued', lastError: null, ...values };
+}
+
+async function ensureCapacity(additionalBytes) {
+    if (await queueUsage() + additionalBytes > MAX_QUEUE_BYTES) throw new Error('The transfer queue is full (200 MB maximum). Remove items and try again.');
+}
+
+export async function removeItem(id) { await transaction('readwrite', store => store.delete(id)); }
+export async function updateItem(item) { await transaction('readwrite', store => store.put(item)); }
+export async function recoverInterruptedItems() {
+    const items = await listQueue();
+    await Promise.all(items.filter(item => item.status === 'sending').map(item => updateItem({ ...item, status: 'queued', lastError: 'Previous transfer was interrupted.' })));
+}

--- a/src/upload/crosspoint_upload.js
+++ b/src/upload/crosspoint_upload.js
@@ -35,23 +35,29 @@ const CrossPointUpload = {
      * @returns {Promise<{success: boolean, error?: string}>}
      */
     async uploadEpub(epubData, filename) {
+        return this.uploadFile({ data: epubData, filename, mimeType: 'application/epub+zip', targetDirectory: this.TARGET_FOLDER });
+    },
+
+    async uploadFile({ data, filename, mimeType, targetDirectory }) {
         console.log('[CrossPoint Upload] Starting upload for:', filename);
-        console.log('[CrossPoint Upload] File size:', epubData.byteLength, 'bytes');
 
         try {
             // Step 1: Ensure target folder exists
-            const folderReady = await this.ensureFolderExists(this.TARGET_FOLDER);
+            const safeFilename = TransferUtils.safeFilename(filename);
+            const safeDirectory = TransferUtils.safeDirectory(targetDirectory);
+            const folderReady = await this.ensureDirectory(safeDirectory);
             if (!folderReady) {
-                console.warn('[CrossPoint Upload] Could not verify/create folder, uploading to root instead');
+                return { success: false, error: `Could not create /${safeDirectory} on CrossPoint` };
             }
 
             // Step 2: Determine upload path
-            const uploadPath = folderReady ? `/${this.TARGET_FOLDER}` : `/`;
+            const resolvedFilename = await this.resolveCollision(safeDirectory, safeFilename);
+            const uploadPath = `/${safeDirectory}`;
 
             console.log('[CrossPoint Upload] Upload path:', uploadPath);
 
             // Step 3: Upload the file
-            return await this.uploadFile(epubData, filename, uploadPath);
+            return await this.uploadRawFile(data, resolvedFilename, uploadPath, mimeType || TransferUtils.mimeTypeFor(safeFilename));
 
         } catch (error) {
             console.error('[CrossPoint Upload] Error:', error);
@@ -65,29 +71,29 @@ const CrossPointUpload = {
      * @returns {Promise<boolean>} - True if folder exists or was created
      */
     async ensureFolderExists(folderName) {
+        return this.ensureDirectory(folderName);
+    },
+
+    async ensureDirectory(directory) {
         try {
-            // Check if folder exists
-            console.log('[CrossPoint Upload] Checking if folder exists:', folderName);
-            const exists = await this.folderExists(folderName);
-
-            if (exists) {
-                console.log('[CrossPoint Upload] Folder already exists');
-                return true;
+            let current = '';
+            for (const segment of TransferUtils.safeDirectory(directory).split('/')) {
+                const parent = current;
+                current = current ? `${current}/${segment}` : segment;
+                if (!await this.folderExists(segment, parent) && !await this.createFolder(segment, parent)) return false;
             }
-
-            // Create folder
-            console.log('[CrossPoint Upload] Creating folder:', folderName);
-            return await this.createFolder(folderName);
+            return true;
 
         } catch (error) {
             console.error('[CrossPoint Upload] Error checking/creating folder:', error);
-            return false; // Continue with root upload
+            return false;
         }
     },
 
-    async folderExists(folderName) {
+    async folderExists(folderName, parent = '') {
         try {
-            const response = await fetch(`${this.listEndpoint}?path=/`, {
+            const directory = parent ? `/${parent}` : '/';
+            const response = await fetch(`${this.listEndpoint}?path=${encodeURIComponent(directory)}`, {
                 method: 'GET'
             });
 
@@ -112,16 +118,33 @@ const CrossPointUpload = {
         }
     },
 
+    async listDirectory(directory) {
+        const response = await fetch(`${this.listEndpoint}?path=${encodeURIComponent('/' + TransferUtils.safeDirectory(directory))}`);
+        if (!response.ok) return [];
+        const items = await response.json();
+        return Array.isArray(items) ? items : [];
+    },
+
+    async resolveCollision(directory, filename) {
+        const names = new Set((await this.listDirectory(directory)).filter(item => item.isDirectory !== true && item.type !== 'dir').map(item => item.name));
+        let attempt = 0;
+        let candidate = filename;
+        while (names.has(candidate)) candidate = TransferUtils.collisionFilename(filename, ++attempt);
+        return candidate;
+    },
+
     /**
      * Create a folder using POST /mkdir
      * @param {string} folderName
      * @returns {Promise<boolean>}
      */
-    async createFolder(folderName) {
+    async createFolder(folderName, parent = '') {
         try {
+            // CrossPoint requires the next path segment plus its parent. Stock's
+            // /edit endpoint, by contrast, receives the cumulative path.
             const formData = new FormData();
             formData.append('name', folderName);
-            formData.append('path', '/');
+            formData.append('path', parent ? `/${parent}` : '/');
 
             const response = await fetch(this.mkdirEndpoint, {
                 method: 'POST',
@@ -152,13 +175,13 @@ const CrossPointUpload = {
      * @param {string} path - Directory path (e.g., "/send-to-x4")
      * @returns {Promise<{success: boolean, error?: string}>}
      */
-    async uploadFile(data, filename, path) {
+    async uploadRawFile(data, filename, path, mimeType = 'application/octet-stream') {
         try {
-            const blob = new Blob([data], { type: 'application/epub+zip' });
+            const blob = new Blob([data], { type: mimeType });
             const formData = new FormData();
 
             // Create file with just the filename
-            const file = new File([blob], filename, { type: 'application/epub+zip' });
+            const file = new File([blob], filename, { type: mimeType });
             formData.append('file', file);
 
             // Add query parameter for path

--- a/src/upload/x4_upload_tab.js
+++ b/src/upload/x4_upload_tab.js
@@ -27,25 +27,29 @@ const X4UploadTab = {
      * @returns {Promise<{success: boolean, error?: string}>}
      */
     async uploadEpub(epubData, filename) {
+        return this.uploadFile({ data: epubData, filename, mimeType: 'application/epub+zip', targetDirectory: this.TARGET_FOLDER });
+    },
+
+    async uploadFile({ data, filename, mimeType, targetDirectory }) {
         console.log('[X4 Upload] Starting upload for:', filename);
-        console.log('[X4 Upload] File size:', epubData.byteLength, 'bytes');
 
         try {
             // Step 1: Ensure target folder exists
-            const folderReady = await this.ensureFolderExists(this.TARGET_FOLDER);
+            const safeFilename = TransferUtils.safeFilename(filename);
+            const safeDirectory = TransferUtils.safeDirectory(targetDirectory);
+            const folderReady = await this.ensureDirectory(safeDirectory);
             if (!folderReady) {
-                console.warn('[X4 Upload] Could not verify/create folder, uploading to root instead');
+                return { success: false, error: `Could not create /${safeDirectory} on X4` };
             }
 
             // Step 2: Determine upload path
-            const uploadPath = folderReady
-                ? `/${this.TARGET_FOLDER}/${filename}`
-                : `/${filename}`;
+            const resolvedFilename = await this.resolveCollision(safeDirectory, safeFilename);
+            const uploadPath = `/${safeDirectory}/${resolvedFilename}`;
 
             console.log('[X4 Upload] Upload path:', uploadPath);
 
             // Step 3: Upload the file
-            return await this.uploadFile(epubData, uploadPath);
+            return await this.uploadRawFile(data, uploadPath, mimeType || TransferUtils.mimeTypeFor(safeFilename));
 
         } catch (error) {
             console.error('[X4 Upload] Error:', error);
@@ -59,23 +63,22 @@ const X4UploadTab = {
      * @returns {Promise<boolean>} - True if folder exists or was created
      */
     async ensureFolderExists(folderName) {
+        return this.ensureDirectory(folderName);
+    },
+
+    async ensureDirectory(directory) {
         try {
-            // Check if folder exists
-            console.log('[X4 Upload] Checking if folder exists:', folderName);
-            const exists = await this.folderExists(folderName);
-
-            if (exists) {
-                console.log('[X4 Upload] Folder already exists');
-                return true;
+            let current = '';
+            for (const segment of TransferUtils.safeDirectory(directory).split('/')) {
+                const parent = current;
+                current = current ? `${current}/${segment}` : segment;
+                if (!await this.folderExists(segment, parent) && !await this.createFolder(current)) return false;
             }
-
-            // Create folder
-            console.log('[X4 Upload] Creating folder:', folderName);
-            return await this.createFolder(folderName);
+            return true;
 
         } catch (error) {
             console.error('[X4 Upload] Error checking/creating folder:', error);
-            return false; // Continue with root upload
+            return false;
         }
     },
 
@@ -84,9 +87,10 @@ const X4UploadTab = {
      * @param {string} folderName 
      * @returns {Promise<boolean>}
      */
-    async folderExists(folderName) {
+    async folderExists(folderName, parent = '') {
         try {
-            const response = await fetch(`${this.LIST_ENDPOINT}?dir=/`, {
+            const directory = parent ? `/${parent}/` : '/';
+            const response = await fetch(`${this.LIST_ENDPOINT}?dir=${encodeURIComponent(directory)}`, {
                 method: 'GET'
             });
 
@@ -109,6 +113,23 @@ const X4UploadTab = {
             console.error('[X4 Upload] Error listing directory:', error);
             return false;
         }
+    },
+
+    async listDirectory(directory) {
+        const response = await fetch(`${this.LIST_ENDPOINT}?dir=${encodeURIComponent('/' + TransferUtils.safeDirectory(directory) + '/')}`);
+        if (!response.ok) return [];
+        const items = await response.json();
+        return Array.isArray(items) ? items : [];
+    },
+
+    async resolveCollision(directory, filename) {
+        // Stock's API supplies the cumulative directory path in the multipart filename.
+        // CrossPoint instead receives the basename and parent directory separately.
+        const names = new Set((await this.listDirectory(directory)).filter(item => item.type !== 'dir').map(item => item.name));
+        let attempt = 0;
+        let candidate = filename;
+        while (names.has(candidate)) candidate = TransferUtils.collisionFilename(filename, ++attempt);
+        return candidate;
     },
 
     /**
@@ -149,13 +170,13 @@ const X4UploadTab = {
      * @param {string} path - Full path including filename (e.g., /send-to-x4/file.epub)
      * @returns {Promise<{success: boolean, error?: string}>}
      */
-    async uploadFile(data, path) {
+    async uploadRawFile(data, path, mimeType = 'application/octet-stream') {
         try {
-            const blob = new Blob([data], { type: 'application/epub+zip' });
+            const blob = new Blob([data], { type: mimeType });
             const formData = new FormData();
 
             // The filename in FormData includes the path
-            const file = new File([blob], path, { type: 'application/epub+zip' });
+            const file = new File([blob], path, { type: mimeType });
             formData.append('data', file, path);
 
             console.log('[X4 Upload] Sending POST to', this.UPLOAD_ENDPOINT);

--- a/src/utils/settings.js
+++ b/src/utils/settings.js
@@ -10,6 +10,7 @@ const Settings = {
         STOCK_IP: 'stockIp',
         CROSSPOINT_IP: 'crosspointIp', // Re-using this key name is fine, but semantically it's now specific
         SETTINGS_PANEL_OPEN: 'settingsPanelOpen',
+        ORGANIZE_BY_DATE: 'organizeByDate',
 
         // Legacy keys for migration
         LEGACY_USE_CROSSPOINT: 'useCrosspointFirmware',
@@ -128,6 +129,10 @@ const Settings = {
         }
     },
 
+    async setOrganizeByDate(enabled) {
+        await browserAPI.storage.sync.set({ [this.KEYS.ORGANIZE_BY_DATE]: !!enabled });
+    },
+
     /**
      * Get all settings
      * @returns {Promise<{firmwareType: string, deviceIp: string, settingsPanelOpen: boolean}>}
@@ -140,7 +145,7 @@ const Settings = {
             let deviceIp;
             const keys = [this.KEYS.STOCK_IP, this.KEYS.CROSSPOINT_IP];
             const result = await browserAPI.storage.sync.get(keys);
-            const panelResult = await browserAPI.storage.sync.get(this.KEYS.SETTINGS_PANEL_OPEN);
+            const panelResult = await browserAPI.storage.sync.get([this.KEYS.SETTINGS_PANEL_OPEN, this.KEYS.ORGANIZE_BY_DATE]);
 
             if (firmwareType === 'crosspoint') {
                 deviceIp = result[this.KEYS.CROSSPOINT_IP] || this.DEFAULTS.CROSSPOINT_IP;
@@ -151,14 +156,16 @@ const Settings = {
             return {
                 firmwareType,
                 deviceIp,
-                settingsPanelOpen: panelResult[this.KEYS.SETTINGS_PANEL_OPEN] || false
+                settingsPanelOpen: panelResult[this.KEYS.SETTINGS_PANEL_OPEN] || false,
+                organizeByDate: panelResult[this.KEYS.ORGANIZE_BY_DATE] || false
             };
         } catch (error) {
             console.error('[Settings] Error getting all settings:', error);
             return {
                 firmwareType: 'stock',
                 deviceIp: '192.168.3.3',
-                settingsPanelOpen: false
+                settingsPanelOpen: false,
+                organizeByDate: false
             };
         }
     }

--- a/src/utils/transfer_utils.js
+++ b/src/utils/transfer_utils.js
@@ -1,0 +1,79 @@
+/* Shared validation for every file sent to an X4. Loaded in popup and worker. */
+const TransferUtils = {
+    SUPPORTED_TYPES: {
+        '.epub': 'application/epub+zip',
+        '.txt': 'text/plain',
+        '.xtc': 'application/x-xtc'
+    },
+
+    extensionFor(filename) {
+        const match = /\.[^.]+$/.exec(String(filename || '').toLowerCase());
+        return match ? match[0] : '';
+    },
+
+    mimeTypeFor(filename) {
+        return this.SUPPORTED_TYPES[this.extensionFor(filename)] || null;
+    },
+
+    safeFilename(filename) {
+        const value = String(filename || '').trim();
+        if (!value || value.length > 180 || /[\\/\0]/.test(value) || value === '.' || value === '..') {
+            throw new Error('Choose a valid filename without path separators.');
+        }
+        if (!this.mimeTypeFor(value)) {
+            throw new Error('Only EPUB, TXT, and XTC files are supported.');
+        }
+        return value;
+    },
+
+    safeDirectory(directory) {
+        const value = String(directory || '').replace(/^\/+|\/+$/g, '');
+        if (!value) throw new Error('A destination folder is required.');
+        const segments = value.split('/');
+        if (segments.some(segment => !segment || segment === '.' || segment === '..' || /[\\\0]/.test(segment))) {
+            throw new Error('Choose a valid destination folder.');
+        }
+        return value;
+    },
+
+    dateFolder(date = new Date()) {
+        const dateOnly = typeof date === 'string' && /^(\d{4})-(\d{2})-(\d{2})$/.exec(date);
+        if (dateOnly) {
+            const [, year, month, day] = dateOnly;
+            const localDate = new Date(Number(year), Number(month) - 1, Number(day));
+            if (localDate.getFullYear() === Number(year) && localDate.getMonth() === Number(month) - 1 && localDate.getDate() === Number(day)) {
+                return date;
+            }
+            return null;
+        }
+        const value = new Date(date);
+        if (Number.isNaN(value.getTime())) return null;
+        return `${value.getFullYear()}-${String(value.getMonth() + 1).padStart(2, '0')}-${String(value.getDate()).padStart(2, '0')}`;
+    },
+
+    destination(baseFolder, organizeByDate, date) {
+        const base = this.safeDirectory(baseFolder);
+        return organizeByDate ? `${base}/${this.dateFolder(date) || this.dateFolder()}` : base;
+    },
+
+    collisionFilename(filename, attempt) {
+        if (!attempt) return filename;
+        const index = filename.lastIndexOf('.');
+        const stem = index > 0 ? filename.slice(0, index) : filename;
+        const extension = index > 0 ? filename.slice(index) : '';
+        return `${stem} (${attempt + 1})${extension}`;
+    },
+
+    isConnectivityError(error) {
+        const message = String(error || '').toLowerCase();
+        return message.includes('cannot reach') ||
+            message.includes('failed to fetch') ||
+            message.includes('network request failed') ||
+            message.includes('networkerror') ||
+            message.includes('timed out') ||
+            message.includes('timeout');
+    }
+};
+
+if (typeof window !== 'undefined') window.TransferUtils = TransferUtils;
+else self.TransferUtils = TransferUtils;

--- a/tests/transfer_utils.test.js
+++ b/tests/transfer_utils.test.js
@@ -1,0 +1,58 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const vm = require('node:vm');
+
+const context = { self: {} };
+vm.runInNewContext(fs.readFileSync('src/utils/transfer_utils.js', 'utf8'), context);
+const utils = context.self.TransferUtils;
+
+function loadUploader(path, name) {
+    const uploaderContext = {
+        self: { TransferUtils: utils },
+        TransferUtils: utils,
+        console: { log() {}, warn() {}, error() {} },
+        fetch: async () => { throw new Error('fetch should not run'); }
+    };
+    vm.runInNewContext(`${fs.readFileSync(path, 'utf8')}; self.__uploader = ${name};`, uploaderContext);
+    return uploaderContext.self.__uploader;
+}
+
+test('recognizes the supported transfer formats', () => {
+    assert.equal(utils.mimeTypeFor('book.epub'), 'application/epub+zip');
+    assert.equal(utils.mimeTypeFor('note.TXT'), 'text/plain');
+    assert.equal(utils.mimeTypeFor('reader.xtc'), 'application/x-xtc');
+    assert.equal(utils.mimeTypeFor('image.png'), null);
+});
+
+test('rejects unsafe filenames and directories', () => {
+    assert.throws(() => utils.safeFilename('../book.epub'));
+    assert.throws(() => utils.safeFilename('book.pdf'));
+    assert.throws(() => utils.safeDirectory('send-to-x4/../root'));
+    assert.equal(utils.safeDirectory('/send-to-x4/2026-07-17/'), 'send-to-x4/2026-07-17');
+});
+
+test('resolves dated destinations and collision names', () => {
+    assert.equal(utils.destination('send-to-x4', true, '2026-07-17'), 'send-to-x4/2026-07-17');
+    assert.equal(utils.dateFolder('2026-07-17'), '2026-07-17');
+    assert.equal(utils.dateFolder('2026-02-30'), null);
+    assert.equal(utils.collisionFilename('Article.epub', 1), 'Article (2).epub');
+    assert.equal(utils.isConnectivityError('Cannot reach X4. Make sure you are on X4 WiFi.'), true);
+    assert.equal(utils.isConnectivityError('Upload failed with status 500'), false);
+});
+
+test('Stock and CrossPoint refuse uploads when the destination cannot be created', async () => {
+    for (const [path, name] of [['src/upload/x4_upload_tab.js', 'X4UploadTab'], ['src/upload/crosspoint_upload.js', 'CrossPointUpload']]) {
+        const uploader = loadUploader(path, name);
+        uploader.ensureDirectory = async () => false;
+        const result = await uploader.uploadFile({ data: new ArrayBuffer(1), filename: 'book.txt', mimeType: 'text/plain', targetDirectory: 'send-to-x4/2026-07-17' });
+        assert.equal(result.success, false);
+        assert.match(result.error, /Could not create/);
+    }
+});
+
+test('Stock collision detection treats every non-directory entry as an existing file', async () => {
+    const uploader = loadUploader('src/upload/x4_upload_tab.js', 'X4UploadTab');
+    uploader.listDirectory = async () => [{ name: 'book.txt' }, { name: 'folder', type: 'dir' }];
+    assert.equal(await uploader.resolveCollision('send-to-x4', 'book.txt'), 'book (2).txt');
+});


### PR DESCRIPTION
## Summary

Adds a local-first transfer queue for Send to X4.

- Queue self-contained article snapshots for later transfer after switching to X4 Wi-Fi.
- Import and transfer EPUB, TXT, and XTC files unchanged.
- Add sequential batch sending, retry/remove controls, and stop-after-current behavior.
- Add optional date folders and recursive managed-folder browsing.
- Generalize Stock and CrossPoint upload paths with safe destinations, supported MIME types, collision handling, and no root-directory fallback.

## Validation

- `node --test tests/transfer_utils.test.js`
- Manifest validation and syntax checks for changed scripts/modules.
- Manual Chrome/X4 smoke testing, including local-file queue transfer.

## Notes

The PR intentionally excludes the unrelated local `MOBILE_APP_SPEC.md` file. Firefox, Edge, and CrossPoint manual validation remain follow-up coverage.